### PR TITLE
fix make error

### DIFF
--- a/include/LSH.h
+++ b/include/LSH.h
@@ -35,8 +35,8 @@ limitations under the License.
 #define FASTLSH_LSH_H
 
 //typedef to make code less verbose
-typedef std::vector<std::vector<std::vector<double>>> vector3D;
-typedef std::vector<std::vector<double>> vector2D;
+typedef std::vector<std::vector<std::vector<double> > > vector3D;
+typedef std::vector<std::vector<double> > vector2D;
 typedef std::vector<double> vector1D;
 
 class LSH{


### PR DESCRIPTION
I got an error when trying to execute make command. This may help for anyone facing the same error as me.

## System
- Ubuntu 14.04.5 LTS
- gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
- SWIG Version 3.0.12
- python 3.6.2

## Error
``` bash
> make
[  9%] Swig source
include/LSH.h:39: Error: Syntax error in input(1).
make[2]: *** [LSHPYTHON_wrap.cxx] Error 1
make[1]: *** [CMakeFiles/_FastLSH.dir/all] Error 2
make: *** [all] Error 2
```