### PR TITLE
Fix: error: ‘bind’ is not a member of ‘std’

### DIFF
--- a/src/Computer/StdThreadComputer.cpp
+++ b/src/Computer/StdThreadComputer.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include <thread>
 #include <algorithm>
 #include <iostream>
+#include <functional>
 #include "../../include/otherClasses/Computer.h"
 
 vector2D ComputerStdThread::computeHash(vector2D dataset, size_t pointNum){


### PR DESCRIPTION
I got an error when trying to execute make command. This may help for anyone facing the same error as me.

## System
- Fedora Server 26
- gcc version 7.2.1 20170915 (Red Hat 7.2.1-2) (GCC) 
- SWIG Version 3.0.12
- Python 3.6.2
## Error
``` zsh
> make
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:51:39: error: ‘bind’ is not a member of ‘std’
         threads[t] = std::thread(std::bind(
                                       ^~~~
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:51:39: note: suggested alternative: ‘find’
         threds[t] = std::thread(std::bind(
                                       ^~~~
                                       find
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp: In member function ‘virtual vector2D ComputerStdThreadNormal::computeCollision(vector2D, vector2D)’:
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:108:39: error: ‘bind’ is not a member of ‘std’
         threads[t] = std::thread(std::bind(
                                       ^~~~
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:108:39: note: suggested alternative: ‘find’
         threads[t] = std::thread(std::bind(
                                       ^~~~
                                       find
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp: In member function ‘virtual vector2D ComputerStdThreadNormal::computeCandidate(vector2D)’:
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:152:39: error: ‘bind’ is not a member of ‘std’
         threads[t] = std::thread(std::bind(
                                       ^~~~
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:152:39: note: suggested alternative: ‘find’
         threads[t] = std::thread(std::bind(
                                       ^~~~
                                       find
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp: In member function ‘virtual vector2D ComputerStdThreadQuick::computeCandidate(vector2D, vector2D)’:
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:192:39: error: ‘bind’ is not a member of ‘std’
         threads[t] = std::thread(std::bind(
                                       ^~~~
/root/a/FastLSH-Python/src/Computer/StdThreadComputer.cpp:192:39: note: suggested alternative: ‘find’
         threads[t] = std::thread(std::bind(
                                       ^~~~
                                       find
make[2]: *** [CMakeFiles/_FastLSH.dir/build.make:240: CMakeFiles/_FastLSH.dir/src/Computer/StdThreadComputer.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/_FastLSH.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

PS I try the updated code(combine the two fix) on both environment(this and Ubuntu)